### PR TITLE
Fixes for the FreeBSD build.

### DIFF
--- a/include/amd.h
+++ b/include/amd.h
@@ -6,7 +6,9 @@
  *  AMD specific prototypes.
  */
 
+#ifdef __linux__
 #include <linux/types.h>
+#endif
 #include <x86info.h>
 
 void decode_athlon_machine_check(int cpunum);

--- a/mtrr.c
+++ b/mtrr.c
@@ -6,7 +6,9 @@
  */
 
 #include <stdio.h>
+#ifdef __linux__
 #include <asm/mtrr.h>
+#endif
 #include <x86info.h>
 
 #define IA32_MTRRCAP_WC   (1 << 10)
@@ -21,6 +23,10 @@
 #define IA32_PHYMASK_VALID  (1 << 11)
 
 static unsigned int max_phy_addr = 0;
+
+#ifndef MTRR_NUM_TYPES
+#define MTRR_NUM_TYPES 8
+#endif
 
 static const char * mtrr_types[MTRR_NUM_TYPES] =
 {

--- a/rdmsr-freebsd.c
+++ b/rdmsr-freebsd.c
@@ -10,9 +10,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
-#include <cpu.h>
-#include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/cpuctl.h>
+#include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <x86info.h>
@@ -22,12 +22,12 @@ int read_msr(int cpu, unsigned int idx, unsigned long long *val)
 	char cpuname[16];
 	int fh;
 	static int nodriver=0;
-	cpu_msr_args_t args;
+	cpuctl_msr_args_t args;
 
 	if (nodriver==1)
 		return 0;
 
-	(void)snprintf(cpuname, sizeof(cpuname), "/dev/cpu%d", cpu);
+	(void)snprintf(cpuname, sizeof(cpuname), "/dev/cpuctl%d", cpu);
 
 	fh = open(cpuname, O_RDONLY);
 	if (fh==-1) {
@@ -37,7 +37,7 @@ int read_msr(int cpu, unsigned int idx, unsigned long long *val)
 	}
 
 	args.msr = idx;
-	if (ioctl(fh, CPU_RDMSR, &args) != 0) {
+	if (ioctl(fh, CPUCTL_RDMSR, &args) != 0) {
 		if (close(fh) == -1) {
 			perror("close");
 			exit(EXIT_FAILURE);

--- a/scripts/testnodes
+++ b/scripts/testnodes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 [ `uname -s` != "Linux" ] && exit 0
 

--- a/vendors/intel/topology.c
+++ b/vendors/intel/topology.c
@@ -11,14 +11,14 @@
 #include "intel.h"
 
 /**
- * fls - find last (most-significant) bit set
+ * tp_fls - find last (most-significant) bit set
  * @x: the word to search
  *
  * This is defined the same way as ffs.
  * Note fls(0) = 0, fls(1) = 1, fls(0x80000000) = 32.
  */
 
-static int fls(int x)
+static int tp_fls(int x)
 {
 	return x ? sizeof(x) * 8 - __builtin_clz(x) : 0;
 }
@@ -27,7 +27,7 @@ static int get_count_order(unsigned int count)
 {
 	int order;
 
-	order = fls(count) - 1;
+	order = tp_fls(count) - 1;
 	if (count & (count - 1))
 		order++;
 	return order;


### PR DESCRIPTION
This changes were required to get x86info actually build on FreeBSD stable/10 amd64.
I did not implemented the cpuid-freebsd.c:bind_cpu() (yet ?).
The lsmsr utility is also not ported.

fls() function conflicts with the same function provided by the FreeBSD libc and strings.h header.
I opted to just rename the local function instead of conditionally use of the system-provided one.

I can split this into more fine-grained chunks if you prefer.
