### PR TITLE
The %ecx register must be cleared for each iteration in dump_raw_cpui…

### DIFF
--- a/cpuid.c
+++ b/cpuid.c
@@ -79,10 +79,11 @@ unsigned int cpuid_ebx(unsigned int CPU_number, unsigned int op)
 void dump_raw_cpuid(int cpunum, unsigned int begin, unsigned int end)
 {
         unsigned int i;
-        unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+        unsigned int eax, ebx, ecx, edx;
 
         /* Dump all the CPUID results in raw hex */
         for (i = begin; i <= end; i++) {
+		ecx = 0;
                 cpuid(cpunum, i, &eax, &ebx, &ecx, &edx);
                 printf("eax in: 0x%08x, eax = %08x ebx = %08x ecx = %08x edx = %08x\n", i, eax, ebx, ecx, edx);
         }


### PR DESCRIPTION
…d().

Stale %ecx value from the first iteration causes wrong request to be
issued by the CPUID instruction.  Before the patch:
eax in: 0x00000007, eax = 00000000 ebx = 00000000 ecx = 00000000 edx = 00000000
after the patch
eax in: 0x00000007, eax = 00000000 ebx = 00002fbb ecx = 00000000 edx = 00000000

Since %ecx must be reset on each iteration, and other registers' values do
not matter, I removed initialization at the declaration for locals in
dump_raw_cpuid().