### PR TITLE
Add rev of the AMD G-T40E.

### DIFF
--- a/include/amd-revision.h
+++ b/include/amd-revision.h
@@ -154,6 +154,7 @@ get_name(fam12h_revision, int, fam12h_revisions);
 
 static struct id_string fam14h_revisions[] = {
 	{0x00500f10, "ON-B0"},
+	{0x00500f20, "ON-C0"},
 };
 get_name(fam14h_revision, int, fam14h_revisions);
 


### PR DESCRIPTION
This is taken from the document 47534  Revision: 3.18 Table 2. CPUID Values for AMD Family 14h Models 00h-0Fh Processor Revisions