### PR TITLE
Use core_id vs. physical_id for counting sockets

### DIFF
--- a/topology.c
+++ b/topology.c
@@ -76,7 +76,7 @@ void display_topology(struct cpudata *head)
 
 	cpu = head;
 	for (i = 0; i < nrCPUs; i++) {
-		sockets[cpu->phys_proc_id]++;
+		sockets[cpu->cpu_core_id]++;
 		cpu = cpu->next;
 	}
 


### PR DESCRIPTION
physical_id returns a unique ID for each physical processor present.

core_id returns a unique ID for each socker/core on the _same_ physical
processor.

Since we are counting sockets, we should core_id, instead of
physical_id.
